### PR TITLE
Feature: add entry cli -> topic: project reboot

### DIFF
--- a/reading_list/cli/cli.py
+++ b/reading_list/cli/cli.py
@@ -6,7 +6,6 @@ import click
 
 from reading_list.core.application.commands import AddEntryCommandHandler
 from reading_list.core.application.inputs import InputEventFactory
-from reading_list.core.application.results import AResult
 from reading_list.core.dependencies.bootstrapper import NaiveBootstrapper
 from reading_list.core.dependencies.dependency_injection import ADependencyInjectionContainer, NaiveDependencyInjectionContainer
 
@@ -25,10 +24,10 @@ def cli() -> None:
 @click.option('-l', '--link',
               help="Link to the reading entry")
 def add(title: str, link: str) -> None:
-    data = InputEventFactory.make_data_input_event(
-        dict(title=title, link=link or ''))
+    data = InputEventFactory.make_data_input_event(dict(
+        title=title, link=link or ''))
     handler = AddEntryCommandHandler(di_container)
-    result: AResult = handler.handle(data)
+    result = handler.handle(data)
     click.echo('Ok.' if result.is_ok() else 'Could not add an entry.')
 
 

--- a/reading_list/cli/cli.py
+++ b/reading_list/cli/cli.py
@@ -14,7 +14,12 @@ di_container = NaiveDependencyInjectionContainer()
 di_container = NaiveBootstrapper(di_container).bootstrap_di()
 
 
-@click.command()
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
 @click.option('-t', '--title', required=True,
               help="Title of the reading entry")
 @click.option('-l', '--link',
@@ -24,4 +29,8 @@ def add(title: str, link: str):
         dict(title=title, link=link or ''))
     handler = AddEntryCommandHandler(di_container)
     result: AResult = handler.handle(data)
-    click.echo('Ok.' if result.is_okay() else 'Could not add an entry.')
+    click.echo('Ok.' if result.is_ok() else 'Could not add an entry.')
+
+
+if __name__ == '__main__':
+    cli()

--- a/reading_list/cli/cli.py
+++ b/reading_list/cli/cli.py
@@ -2,8 +2,26 @@
 # 1. build click command runtime for adding new reading list entries
 # 2. refactor dependency injection bootstrapping
 # 3. implement the click command runtime for listing list entries
+import click
 
-from reading_list.core.persistency.tinydb_driver import TinyDbDriver
-from reading_list.core.domain.entities import ReadingEntryFactory
-from reading_list.core.dependencies.dependency_injection import NaiveDependencyInjectionContainer
+from reading_list.core.application.commands import AddEntryCommandHandler
+from reading_list.core.application.inputs import InputEventFactory
+from reading_list.core.application.results import AResult
 from reading_list.core.dependencies.bootstrapper import NaiveBootstrapper
+from reading_list.core.dependencies.dependency_injection import NaiveDependencyInjectionContainer
+
+di_container = NaiveDependencyInjectionContainer()
+di_container = NaiveBootstrapper(di_container).bootstrap_di()
+
+
+@click.command()
+@click.option('-t', '--title', required=True,
+              help="Title of the reading entry")
+@click.option('-l', '--link',
+              help="Link to the reading entry")
+def add(title: str, link: str):
+    data = InputEventFactory.make_data_input_event(
+        dict(title=title, link=link or ''))
+    handler = AddEntryCommandHandler(di_container)
+    result: AResult = handler.handle(data)
+    click.echo('Ok.' if result.is_okay() else 'Could not add an entry.')

--- a/reading_list/cli/cli.py
+++ b/reading_list/cli/cli.py
@@ -8,9 +8,9 @@ from reading_list.core.application.commands import AddEntryCommandHandler
 from reading_list.core.application.inputs import InputEventFactory
 from reading_list.core.application.results import AResult
 from reading_list.core.dependencies.bootstrapper import NaiveBootstrapper
-from reading_list.core.dependencies.dependency_injection import NaiveDependencyInjectionContainer
+from reading_list.core.dependencies.dependency_injection import ADependencyInjectionContainer, NaiveDependencyInjectionContainer
 
-di_container = NaiveDependencyInjectionContainer()
+di_container: ADependencyInjectionContainer = NaiveDependencyInjectionContainer()
 di_container = NaiveBootstrapper(di_container).bootstrap_di()
 
 

--- a/reading_list/cli/cli.py
+++ b/reading_list/cli/cli.py
@@ -15,7 +15,7 @@ di_container = NaiveBootstrapper(di_container).bootstrap_di()
 
 
 @click.group()
-def cli():
+def cli() -> None:
     pass
 
 
@@ -24,7 +24,7 @@ def cli():
               help="Title of the reading entry")
 @click.option('-l', '--link',
               help="Link to the reading entry")
-def add(title: str, link: str):
+def add(title: str, link: str) -> None:
     data = InputEventFactory.make_data_input_event(
         dict(title=title, link=link or ''))
     handler = AddEntryCommandHandler(di_container)

--- a/reading_list/core/application/commands.py
+++ b/reading_list/core/application/commands.py
@@ -1,6 +1,7 @@
 from reading_list.core.application.inputs import DataInputEvent
 from reading_list.core.application.results import AResult, SuccessResult, ErrorResult
 from reading_list.core.dependencies.dependency_injection import ADependencyInjectionContainer
+from reading_list.core.dependencies.bootstrapper import DependencyInjectionEntryKeys
 
 
 class BaseHandler:
@@ -82,7 +83,10 @@ class AddEntryCommandHandler(BaseHandler):
             >>> isinstance(result, ErrorResult)
             True
         """
-        reading_factory = self._di.get('reading_entry_factory')
+        reading_factory = self._di.get(
+            DependencyInjectionEntryKeys.READING_ENTRY_FACTORY)
+        persistency_driver = self._di.get(
+            DependencyInjectionEntryKeys.PERSISTENCE_DRIVER)
         reading_entry = reading_factory.struct_to_entity(event.data)
-        result = self._di.get('persistence_driver').save(reading_entry)
+        result = persistency_driver.save(reading_entry)
         return SuccessResult() if result else ErrorResult()

--- a/reading_list/core/application/inputs.py
+++ b/reading_list/core/application/inputs.py
@@ -5,3 +5,16 @@ from dataclasses import dataclass, field
 @dataclass
 class DataInputEvent:
     data: Dict[str, Any] = field(default_factory=dict)
+
+class InputEventFactory:
+    @staticmethod
+    def make_data_input_event(data_body: Dict[str, Any]) -> DataInputEvent:
+        """Examples:
+            1. Creates a DataInputEvent with provided body
+            >>> result = InputEventFactory.make_data_input_event({'foo':'bar'})
+            >>> isinstance(result, DataInputEvent)
+            True
+            >>> result.data
+            {'foo': 'bar'}
+        """
+        return DataInputEvent(data=data_body)

--- a/reading_list/core/application/results.py
+++ b/reading_list/core/application/results.py
@@ -12,7 +12,7 @@ class AResult:
     STATUS = ResultStatuses.BASE
 
     @classmethod
-    def is_ok(cls):
+    def is_ok(cls) -> bool:
         return cls.STATUS == ResultStatuses.SUCCESS
 
 

--- a/reading_list/core/application/results.py
+++ b/reading_list/core/application/results.py
@@ -1,10 +1,33 @@
+class ResultStatuses:
+    BASE = 'base'
+    SUCCESS = 'success'
+    ERROR = 'error'
+
 class AResult:
-    STATUS = 'base'
+    """Examples:
+        >>> result = AResult()
+        >>> result.is_ok()
+        False
+    """
+    STATUS = ResultStatuses.BASE
+
+    @classmethod
+    def is_ok(cls):
+        return cls.STATUS == ResultStatuses.SUCCESS
 
 
 class SuccessResult(AResult):
-    STATUS = 'success'
-
+    """Examples:
+        >>> result = SuccessResult()
+        >>> result.is_ok()
+        True
+    """
+    STATUS = ResultStatuses.SUCCESS
 
 class ErrorResult(AResult):
-    STATUS = 'error'
+    """Examples:
+        >>> result = ErrorResult()
+        >>> result.is_ok()
+        False
+    """
+    STATUS = ResultStatuses.ERROR

--- a/reading_list/core/dependencies/bootstrapper.py
+++ b/reading_list/core/dependencies/bootstrapper.py
@@ -22,11 +22,19 @@ class BootstrapperValueFactories:
 
 class NaiveBootstrapper:
     def __init__(self, container: ADependencyInjectionContainer) -> None:
-        self._container = container
+        """Examples:
+            1. New bootstrapper takes in the container
+            >>> from unittest.mock import MagicMock
+            >>> mock_di_container = MagicMock()
+            >>> test_instance = NaiveBootstrapper(mock_di_container)
+            >>> test_instance._di_container == mock_di_container
+            True
+        """
+        self._di_container = container
 
     def bootstrap_di(self) -> ADependencyInjectionContainer:
-        self._container.register(DependencyInjectionEntryKeys.READING_ENTRY_FACTORY,
+        self._di_container.register(DependencyInjectionEntryKeys.READING_ENTRY_FACTORY,
                                  BootstrapperValueFactories.READING_ENTRY_FACTORY(self))
-        self._container.register(DependencyInjectionEntryKeys.PERSISTENCE_DRIVER,
-                                 BootstrapperValueFactories.PERSISTENCE_DRIVER(self._container))
-        return self._container
+        self._di_container.register(DependencyInjectionEntryKeys.PERSISTENCE_DRIVER,
+                                 BootstrapperValueFactories.PERSISTENCE_DRIVER(self._di_container))
+        return self._di_container

--- a/reading_list/core/dependencies/dependency_injection.py
+++ b/reading_list/core/dependencies/dependency_injection.py
@@ -23,6 +23,11 @@ class NaiveDependencyInjectionContainer(ADependencyInjectionContainer):
         >>> di = NaiveDependencyInjectionContainer()
         >>> di._container
         {}
+
+        2. Is a subclass of ADependencyInjectionContainer
+        >>> di = NaiveDependencyInjectionContainer()
+        >>> isinstance(di, ADependencyInjectionContainer)
+        True
     """
 
     def register(self, key: str, item: Any) -> bool:

--- a/reading_list/core/dependencies/dependency_injection.py
+++ b/reading_list/core/dependencies/dependency_injection.py
@@ -3,6 +3,9 @@ from abc import ABC, abstractmethod
 
 
 class ADependencyInjectionContainer(ABC):
+    def __init__(self) -> None:
+        super().__init__()
+        self._container: Dict[str, Any] = {}
 
     @abstractmethod
     def register(self, key: str, item: Any) -> bool:
@@ -21,7 +24,6 @@ class NaiveDependencyInjectionContainer(ADependencyInjectionContainer):
         >>> di._container
         {}
     """
-    _container: Dict[str, Any] = {}
 
     def register(self, key: str, item: Any) -> bool:
         """Examples:

--- a/reading_list/core/persistency/tinydb_driver.py
+++ b/reading_list/core/persistency/tinydb_driver.py
@@ -63,7 +63,7 @@ class TinyDbDriver:
             >>> with patch.object(TinyDbDriver, '_db', new_callable=PropertyMock) as mock_db:
             ...     with patch('reading_list.core.persistency.tinydb_driver.Document') as mock_document:
             ...         reset_mocks()
-            ...         _ = setup_mock_factory()
+            ...         setup_mock_factory()
             ...         driver = TinyDbDriver(di)
             ...         _ = driver._throwing_save(test_input_entry)
             ...         mock_factory.entity_to_struct.assert_called_once_with(test_input_entry)

--- a/reading_list/core/persistency/tinydb_driver.py
+++ b/reading_list/core/persistency/tinydb_driver.py
@@ -106,8 +106,7 @@ class TinyDbDriver:
         reading_entry_struct: ReadingEntryStruct = factory.entity_to_struct(
             reading_entry)
         document_to_store = Document(
-            reading_entry_struct,
-            doc_id=self._get_document_id(reading_entry_struct))
+            reading_entry_struct, doc_id=self._get_document_id(reading_entry_struct))
         entry_id = self._db.insert(document_to_store)
         return True if entry_id else False
 

--- a/reading_list/core/persistency/tinydb_driver.py
+++ b/reading_list/core/persistency/tinydb_driver.py
@@ -1,6 +1,7 @@
 from tinydb import TinyDB
+from tinydb.table import Document
 
-from reading_list.core.domain.entities import ReadingEntry
+from reading_list.core.domain.entities import ReadingEntry, ReadingEntryStruct
 from reading_list.core.dependencies.dependency_injection import ADependencyInjectionContainer
 
 
@@ -40,46 +41,107 @@ class TinyDbDriver:
     def _throwing_save(self, reading_entry: ReadingEntry) -> bool:
         """Examples:
 
-            >>> from unittest.mock import MagicMock, patch
+            >>> from unittest.mock import MagicMock, PropertyMock, patch
             >>> mock_factory = MagicMock()
             >>> di = dict(reading_entry_factory=mock_factory)
             >>> test_input_entry = MagicMock()
+            >>> test_input_entry.title = "some_title"
+            >>> test_input_entry.link = "some_link"
+            >>> def get_test_entry_struct(reading_entry):
+            ...     return dict(title=reading_entry.title, link=reading_entry.link)
+            >>> def setup_mock_db(mock_db):
+            ...     mock_db_instance = MagicMock()
+            ...     mock_db.return_value = mock_db_instance
+            ...     return mock_db_instance
+            >>> def setup_mock_factory():
+            ...     expected_struct = get_test_entry_struct(test_input_entry)
+            ...     mock_factory.entity_to_struct.return_value = expected_struct
             >>> def reset_mocks():
             ...     mock_factory.reset_mock()
 
             1. TinyDbDriver::_throwing_save uses the struct of the reading entry
-            >>> with patch.object(TinyDbDriver, '_db') as mock_db:
-            ...     reset_mocks()
-            ...     driver = TinyDbDriver(di)
-            ...     _ = driver._throwing_save(test_input_entry)
-            ...     mock_factory.entity_to_struct.assert_called_once_with(test_input_entry)
+            >>> with patch.object(TinyDbDriver, '_db', new_callable=PropertyMock) as mock_db:
+            ...     with patch('reading_list.core.persistency.tinydb_driver.Document') as mock_document:
+            ...         reset_mocks()
+            ...         _ = setup_mock_factory()
+            ...         driver = TinyDbDriver(di)
+            ...         _ = driver._throwing_save(test_input_entry)
+            ...         mock_factory.entity_to_struct.assert_called_once_with(test_input_entry)
 
             2. TinyDbDriver::_throwing_save saves the struct of the reading entry
-            >>> with patch.object(TinyDbDriver, '_db') as mock_db:
-            ...     reset_mocks()
-            ...     expected_struct = "some_struct"
-            ...     mock_factory.entity_to_struct.return_value = expected_struct
-            ...     driver = TinyDbDriver(di)
-            ...     _ = driver._throwing_save(test_input_entry)
-            ...     mock_db.insert.assert_called_once_with(expected_struct)
+            >>> with patch.object(TinyDbDriver, '_db', new_callable=PropertyMock) as mock_db:
+            ...     with patch('reading_list.core.persistency.tinydb_driver.Document') as mock_document:
+            ...         reset_mocks()
+            ...         setup_mock_factory()
+            ...         mock_db_instance = setup_mock_db(mock_db)
+            ...         expected_document = "some_document"
+            ...         mock_document.return_value = expected_document
+            ...         driver = TinyDbDriver(di)
+            ...         _ = driver._throwing_save(test_input_entry)
+            ...         mock_db_instance.insert.assert_called_once_with(expected_document)
 
             3. TinyDbDriver::_throwing_save returns True if the result of insert is a valid document id
-            >>> with patch.object(TinyDbDriver, '_db') as mock_db:
-            ...     reset_mocks()
-            ...     mock_db.insert.return_value = "some_valid_document_id"
-            ...     driver = TinyDbDriver(di)
-            ...     driver._throwing_save(test_input_entry)
+            >>> with patch.object(TinyDbDriver, '_db', new_callable=PropertyMock) as mock_db:
+            ...     with patch('reading_list.core.persistency.tinydb_driver.Document') as mock_document:
+            ...         reset_mocks()
+            ...         setup_mock_factory()
+            ...         mock_db_instance = setup_mock_db(mock_db)
+            ...         mock_db_instance.insert.return_value = "some_valid_document_id"
+            ...         driver = TinyDbDriver(di)
+            ...         driver._throwing_save(test_input_entry)
             True
 
             4. TinyDbDriver::_throwing_save returns False if the result of insert is not a valid document id
-            >>> with patch.object(TinyDbDriver, '_db') as mock_db:
-            ...     reset_mocks()
-            ...     mock_db.insert.return_value = None
-            ...     driver = TinyDbDriver(di)
-            ...     driver._throwing_save(test_input_entry)
+            >>> with patch.object(TinyDbDriver, '_db', new_callable=PropertyMock) as mock_db:
+            ...     with patch('reading_list.core.persistency.tinydb_driver.Document') as mock_document:
+            ...         reset_mocks()
+            ...         setup_mock_factory()
+            ...         mock_db_instance = setup_mock_db(mock_db)
+            ...         mock_db_instance.insert.return_value = None
+            ...         driver = TinyDbDriver(di)
+            ...         driver._throwing_save(test_input_entry)
             False
         """
         factory = self._di.get('reading_entry_factory')
-        reading_entry_struct = factory.entity_to_struct(reading_entry)
-        entry_id = self._db.insert(reading_entry_struct)
+        reading_entry_struct: ReadingEntryStruct = factory.entity_to_struct(
+            reading_entry)
+        document_to_store = Document(
+            reading_entry_struct,
+            doc_id=self._get_document_id(reading_entry_struct))
+        entry_id = self._db.insert(document_to_store)
         return True if entry_id else False
+
+    def _get_document_id(self, reading_entry_struct: ReadingEntryStruct) -> int:
+        """Examples:
+
+            >>> from unittest.mock import MagicMock, patch
+            >>> mock_factory = MagicMock()
+            >>> di = dict(reading_entry_factory=mock_factory)
+            >>> test_instance = TinyDbDriver(di)
+
+            1. Returns same integer for same reading_entry_struct titles
+            >>> entry_a = dict(title="carl")
+            >>> entry_b = dict(title="carl")
+            >>> id_a = test_instance._get_document_id(entry_a)
+            >>> id_b = test_instance._get_document_id(entry_b)
+            >>> id_a == id_b
+            True
+
+            2. Returns same integer for reading_entry_struct titles ingoring capital cases
+            >>> entry_a = dict(title="carl")
+            >>> entry_b = dict(title="CaRl")
+            >>> id_a = test_instance._get_document_id(entry_a)
+            >>> id_b = test_instance._get_document_id(entry_b)
+            >>> id_a == id_b
+            True
+
+            3. Returns different integers for reading_entry_struct with different titles
+            >>> entry_a = dict(title="carl")
+            >>> entry_b = dict(title="CaRlos Iv")
+            >>> id_a = test_instance._get_document_id(entry_a)
+            >>> id_b = test_instance._get_document_id(entry_b)
+            >>> id_a == id_b
+            False
+        """
+        lower_title = reading_entry_struct['title'].lower()
+        return int.from_bytes(lower_title.encode(), byteorder='big')


### PR DESCRIPTION
# What

This MR adds basic support for `cli` command to `add` new reading entries. 

## Changes

- [x] Added the [`click`](https://click.palletsprojects.com/en/8.0.x/)-powered cli `add` command
- [x] TinyDbDriver does not allow to save the entries with the same `title` 
- [x] Fixed a few di-container issues 