### PR TITLE
Ft cleanup tp project reboot

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = H301, H306, H101
+max-line-length = 99

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -21,9 +21,9 @@ jobs:
           python -m pip install --upgrade pip
           make requirements-core
           make requirements-dev
-      - name: Lint
+      - name: Run flake8 checks
         run: |
-          make lint
+          make flake8
       - name: Run (unit) tests
         run: |
           make test

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-virtualenv-setup:
+venv:
 	virtualenv .venv
+	echo "Done, now you can activate your virtualenv via from .venv folder."
 requirements-core:
 	pip3 install -r ./requirements/requirements.txt
 requirements-dev:
 	pip3 install -r ./requirements/requirements.dev.txt
 test:
 	pytest reading_list/ --doctest-modules -vvv
-lint:
-	pylint reading_list/
+flake8:
+	flake8 --doctests --statistics --count reading_list
 mypy:
 	mypy reading_list/ --ignore-missing-imports --strict

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,5 @@ flake8:
 	flake8 --doctests --statistics --count reading_list
 mypy:
 	mypy reading_list/ --ignore-missing-imports --strict
+isort:
+	isort -p reading_list -l 99 -e reading_list

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ python3 -m reading_list.cli.cli \
 
 | Setting Path | `<Type>:=<default>` | Description |
 | ------------ | ---- | ----------- |
-| `db. tiny_db.location` | `str:='db.json'` | A path for the TinyDB database file |
+| `db.tiny_db.location` | `str:='db.json'` | A path for the TinyDB database file |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ python3 -m reading_list.cli.cli \
 
 ### Pre-Requisites
 
-- [`Python 3.7+`](https://www.python.org/downloads/)
+- [`Python 3.8+`](https://www.python.org/downloads/)
 - [`make`](https://www.gnu.org/software/make/)
 
 ### Utilities

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ check the [`Makefile`](./Makefile) contents.
 #### Setup virtual environment
 
 ```bash
-$ make virtualenv-setup
+$ make venv
 virtualenv .venv
 created virtual environment ...
 $ . .venv/bin/activate # or appropriate command for your system
@@ -90,6 +90,6 @@ pytest reading_list/ --doctest-modules -vvv
 #### Lint & Type Checking
 
 ```bash
-$ make lint # run the python linter
+$ make flake8 # run the flake8 python style checks
 $ make mypy # run the mypy type checker
 ```

--- a/README.md
+++ b/README.md
@@ -92,4 +92,5 @@ pytest reading_list/ --doctest-modules -vvv
 ```bash
 $ make flake8 # run the flake8 python style checks
 $ make mypy # run the mypy type checker
+$ make isort # run automated import sorting on all reading_list files (modifies files!)
 ```

--- a/reading_list/cli/cli.py
+++ b/reading_list/cli/cli.py
@@ -1,19 +1,24 @@
 from typing import List
+
 import click
 
-from reading_list.core.application.commands import AddEntryCommandHandler, ListEntriesCommandHandler
+from reading_list.core.application.commands import (AddEntryCommandHandler,
+                                                    ListEntriesCommandHandler)
 from reading_list.core.application.inputs import InputEventFactory
-from reading_list.core.dependencies.bootstrapper import ADependencyInjectionBootstrapper, NaiveDependencyInjectionBootstrapper
-from reading_list.core.dependencies.dependency_injection import ADependencyInjectionContainer, NaiveDependencyInjectionContainer
+from reading_list.core.dependencies.bootstrapper import (
+    ADependencyInjectionBootstrapper, NaiveDependencyInjectionBootstrapper)
+from reading_list.core.dependencies.dependency_injection import (
+    ADependencyInjectionContainer, NaiveDependencyInjectionContainer)
 from reading_list.core.domain.entities import ReadingEntry
-from reading_list.shared.config import AConfig, DEFAULT_CONFIGS, initialize_custom_configs
+from reading_list.shared.config import (DEFAULT_CONFIGS, AConfig,
+                                        initialize_custom_configs)
 
 
 class AppStarter:
     def __init__(self) -> None:
-        self.di_container: ADependencyInjectionContainer = NaiveDependencyInjectionContainer()
-        self.di_bootstrapper: ADependencyInjectionBootstrapper = NaiveDependencyInjectionBootstrapper(
-            self.di_container)
+        self.di_container: ADependencyInjectionContainer = NaiveDependencyInjectionContainer() # noqa
+        self.di_bootstrapper: ADependencyInjectionBootstrapper = NaiveDependencyInjectionBootstrapper( # noqa
+            self.di_container) # noqa
 
     def setup_di_with_configs(self, configs: AConfig) -> None:
         self.di_container = self.di_bootstrapper.bootstrap_with_configurations(

--- a/reading_list/cli/cli.py
+++ b/reading_list/cli/cli.py
@@ -5,13 +5,12 @@ import click
 from reading_list.core.application.commands import (AddEntryCommandHandler,
                                                     ListEntriesCommandHandler)
 from reading_list.core.application.inputs import InputEventFactory
-from reading_list.core.dependencies.bootstrapper import (
-    ADependencyInjectionBootstrapper, NaiveDependencyInjectionBootstrapper)
-from reading_list.core.dependencies.dependency_injection import (
-    ADependencyInjectionContainer, NaiveDependencyInjectionContainer)
+from reading_list.core.dependencies.bootstrapper import (ADependencyInjectionBootstrapper,
+                                                         NaiveDependencyInjectionBootstrapper)
+from reading_list.core.dependencies.dependency_injection import (ADependencyInjectionContainer,
+                                                                 NaiveDependencyInjectionContainer)
 from reading_list.core.domain.entities import ReadingEntry
-from reading_list.shared.config import (DEFAULT_CONFIGS, AConfig,
-                                        initialize_custom_configs)
+from reading_list.shared.config import DEFAULT_CONFIGS, AConfig, initialize_custom_configs
 
 
 class AppStarter:

--- a/reading_list/core/application/commands.py
+++ b/reading_list/core/application/commands.py
@@ -15,7 +15,8 @@ class BaseHandler:
 
     def handle(self, event: DataInputEvent) -> AResult:
         """Examples:
-            >>> from unittest.mock import MagicMock, patch
+
+            >>> from unittest.mock import patch
             >>> def get_base_handler():
             ...     di = dict()
             ...     return BaseHandler(di)
@@ -37,14 +38,15 @@ class BaseHandler:
         """
         try:
             return self._own_handle(event)
-        except:
+        except Exception:
             return ErrorResult()
 
 
 class AddEntryCommandHandler(BaseHandler):
     def _own_handle(self, event: DataInputEvent) -> AResult:
         """Examples:
-            >>> from unittest.mock import MagicMock, patch
+
+            >>> from unittest.mock import MagicMock
             >>> mock_factory = MagicMock()
             >>> mock_persistence = MagicMock()
             >>> di = dict(reading_entry_factory=mock_factory, persistence_driver=mock_persistence)
@@ -55,11 +57,13 @@ class AddEntryCommandHandler(BaseHandler):
             ...     mock_factory.reset_mock()
             ...     mock_persistence.reset_mock()
 
-            1. AddEntryCommandHandler::_own_handle cleans the incoming data into a reading entry struct
+            1. AddEntryCommandHandler::_own_handle
+                cleans the incoming data into a reading entry struct
             >>> reset_mocks()
             >>> _ = command_handler._own_handle(mock_event)
             >>> mock_factory.struct_to_entity.assert_called_once_with(mock_event.data)
-            >>> mock_factory.entity_to_struct.assert_called_once_with(mock_factory.struct_to_entity.return_value)
+            >>> mock_factory.entity_to_struct.assert_called_once_with(
+            ...     mock_factory.struct_to_entity.return_value)
 
             2. AddEntryCommandHandler::_own_handle saves the clean struct
             >>> reset_mocks()
@@ -97,7 +101,8 @@ class AddEntryCommandHandler(BaseHandler):
 class ListEntriesCommandHandler(BaseHandler):
     def _own_handle(self, _: DataInputEvent) -> AResult:
         """Examples:
-            >>> from unittest.mock import MagicMock, patch
+
+            >>> from unittest.mock import MagicMock
             >>> mock_factory = MagicMock()
             >>> mock_persistence = MagicMock()
             >>> di = dict(reading_entry_factory=mock_factory, persistence_driver=mock_persistence)
@@ -107,12 +112,14 @@ class ListEntriesCommandHandler(BaseHandler):
             ...     mock_factory.reset_mock()
             ...     mock_persistence.reset_mock()
 
-            1. ListEntriesCommandHandler::_own_handle retrieves a list of structs from the persistency driver
+            1. ListEntriesCommandHandler::_own_handle
+                retrieves a list of structs from the persistency driver
             >>> reset_mocks()
             >>> _ = command_handler._own_handle(mock_event)
             >>> mock_persistence.list.assert_called_once_with()
 
-            2. ListEntriesCommandHandler::_own_handle returns a list of entries as data of the result
+            2. ListEntriesCommandHandler::_own_handle
+                returns a list of entries as data of the result
             >>> reset_mocks()
             >>> expected_reading_entry_structs = ['a', 'b', 'c']
             >>> mock_persistence.list.return_value = expected_reading_entry_structs

--- a/reading_list/core/application/commands.py
+++ b/reading_list/core/application/commands.py
@@ -1,9 +1,10 @@
 from typing import List
-from reading_list.core.domain.entities import ReadingEntry, ReadingEntryStruct
+
 from reading_list.core.application.inputs import DataInputEvent
-from reading_list.core.application.results import AResult, SuccessResult, ErrorResult
+from reading_list.core.application.results import AResult, ErrorResult, SuccessResult
 from reading_list.core.dependencies.dependency_injection import ADependencyInjectionContainer
 from reading_list.core.dependencies.keys import DependencyInjectionEntryKeys
+from reading_list.core.domain.entities import ReadingEntry, ReadingEntryStruct
 
 
 class BaseHandler:

--- a/reading_list/core/application/inputs.py
+++ b/reading_list/core/application/inputs.py
@@ -1,5 +1,5 @@
-from typing import Dict, Any
 from dataclasses import dataclass, field
+from typing import Any, Dict
 
 
 @dataclass

--- a/reading_list/core/application/inputs.py
+++ b/reading_list/core/application/inputs.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Dict, Any
 from dataclasses import dataclass, field
 
 
@@ -6,10 +6,12 @@ from dataclasses import dataclass, field
 class DataInputEvent:
     data: Dict[str, Any] = field(default_factory=dict)
 
+
 class InputEventFactory:
     @staticmethod
     def make_data_input_event(data_body: Dict[str, Any]) -> DataInputEvent:
         """Examples:
+
             1. Creates a DataInputEvent with provided body
             >>> result = InputEventFactory.make_data_input_event({'foo':'bar'})
             >>> isinstance(result, DataInputEvent)

--- a/reading_list/core/application/results.py
+++ b/reading_list/core/application/results.py
@@ -9,6 +9,7 @@ class ResultStatuses:
 
 class AResult:
     """Examples:
+
         >>> result = AResult()
         >>> result.is_ok()
         False
@@ -17,7 +18,8 @@ class AResult:
 
     def __init__(self, data: Optional[Dict[str, Any]] = None) -> None:
         """Examples:
-            >>> data = {'foo': 'bar'} 
+
+            >>> data = {'foo': 'bar'}
             >>> result = AResult(data=data)
             >>> result.data == data
             True
@@ -31,6 +33,7 @@ class AResult:
 
 class SuccessResult(AResult):
     """Examples:
+
         >>> result = SuccessResult()
         >>> result.is_ok()
         True
@@ -40,6 +43,7 @@ class SuccessResult(AResult):
 
 class ErrorResult(AResult):
     """Examples:
+
         >>> result = ErrorResult()
         >>> result.is_ok()
         False

--- a/reading_list/core/dependencies/bootstrapper.py
+++ b/reading_list/core/dependencies/bootstrapper.py
@@ -29,6 +29,7 @@ class ADependencyInjectionBootstrapper(ABC):
 class NaiveDependencyInjectionBootstrapper(ADependencyInjectionBootstrapper):
     def __init__(self, container: ADependencyInjectionContainer) -> None:
         """Examples:
+
             1. New bootstrapper takes in the container
             >>> from unittest.mock import MagicMock
             >>> mock_di_container = MagicMock()
@@ -41,8 +42,10 @@ class NaiveDependencyInjectionBootstrapper(ADependencyInjectionBootstrapper):
     def bootstrap_with_configurations(self, configs: AConfig) -> ADependencyInjectionContainer:
         self._di_container.register(DependencyInjectionEntryKeys.APP_CONFIGS,
                                     configs)
-        self._di_container.register(DependencyInjectionEntryKeys.READING_ENTRY_FACTORY,
-                                    BootstrapperValueFactories.READING_ENTRY_FACTORY(self))
-        self._di_container.register(DependencyInjectionEntryKeys.PERSISTENCE_DRIVER,
-                                    BootstrapperValueFactories.PERSISTENCE_DRIVER(self._di_container))
+        self._di_container.register(
+            DependencyInjectionEntryKeys.READING_ENTRY_FACTORY,
+            BootstrapperValueFactories.READING_ENTRY_FACTORY(self))
+        self._di_container.register(
+            DependencyInjectionEntryKeys.PERSISTENCE_DRIVER,
+            BootstrapperValueFactories.PERSISTENCE_DRIVER(self._di_container))
         return self._di_container

--- a/reading_list/core/dependencies/dependency_injection.py
+++ b/reading_list/core/dependencies/dependency_injection.py
@@ -1,5 +1,5 @@
-from typing import Any, Dict
 from abc import ABC, abstractmethod
+from typing import Any, Dict
 
 
 class ADependencyInjectionContainer(ABC):

--- a/reading_list/core/domain/entities.py
+++ b/reading_list/core/domain/entities.py
@@ -1,5 +1,5 @@
-from typing import TypedDict
 from dataclasses import dataclass
+from typing import TypedDict
 
 
 @dataclass
@@ -17,7 +17,8 @@ class ReadingEntryFactory:
 
     @staticmethod
     def make_new_entry(title: str, link: str = "") -> ReadingEntry:
-        """Examples
+        """Examples:
+
             Entry with title and link
             >>> result = ReadingEntryFactory.make_new_entry('foo', 'bar')
             >>> f't: {result.title}, l: {result.link}'
@@ -40,6 +41,7 @@ class ReadingEntryFactory:
     @staticmethod
     def entity_to_struct(entry: ReadingEntry) -> ReadingEntryStruct:
         """Examples:
+
             >>> reading_entry = ReadingEntry('foo', 'bar')
             >>> ReadingEntryFactory.entity_to_struct(reading_entry)
             {'title': 'foo', 'link': 'bar'}
@@ -49,6 +51,7 @@ class ReadingEntryFactory:
     @classmethod
     def struct_to_entity(cls, entry_struct: ReadingEntryStruct) -> ReadingEntry:
         """Examples:
+
             >>> reading_entry_struct = {'title': 'foo', 'link': 'bar'}
             >>> result = ReadingEntryFactory.struct_to_entity(reading_entry_struct)
             >>> f't: {result.title}, l: {result.link}'

--- a/reading_list/core/persistency/tinydb_driver.py
+++ b/reading_list/core/persistency/tinydb_driver.py
@@ -1,11 +1,13 @@
-from reading_list.core.dependencies.keys import DependencyInjectionEntryKeys
 from typing import List, Optional, cast
+
 from tinydb import TinyDB
 from tinydb.table import Document
 
+from reading_list.core.dependencies.dependency_injection import \
+    ADependencyInjectionContainer
+from reading_list.core.dependencies.keys import DependencyInjectionEntryKeys
 from reading_list.core.domain.entities import ReadingEntryStruct
-from reading_list.core.dependencies.dependency_injection import ADependencyInjectionContainer
-from reading_list.shared.config import Config, DEFAULT_CONFIGS
+from reading_list.shared.config import DEFAULT_CONFIGS, Config
 
 
 class TinyDbDriver:
@@ -60,6 +62,7 @@ class TinyDbDriver:
 
     def _throwing_save(self, reading_entry_struct: ReadingEntryStruct) -> bool:
         """Examples:
+
             >>> from unittest.mock import MagicMock, PropertyMock, patch
             >>> di = dict()
             >>> test_input_entry_struct = dict(title='foo', link='bar')
@@ -68,42 +71,54 @@ class TinyDbDriver:
             ...     mock_db.return_value = mock_db_instance
             ...     return mock_db_instance
 
-            1. TinyDbDriver::_throwing_save saves the struct of the reading entry as new Document with custom id
+            1. TinyDbDriver::_throwing_save
+                saves the reading entry struct as new Document with custom id
             >>> with patch.object(TinyDbDriver, '_db', new_callable=PropertyMock) as mock_db:
             ...     with patch.object(TinyDbDriver, '_get_document_id') as mock_get_document_id:
-            ...         with patch('reading_list.core.persistency.tinydb_driver.Document') as mock_document:
+            ...         with patch(
+            ...                 'reading_list.core.persistency.tinydb_driver.Document'
+            ...         ) as mock_document:
             ...             mock_db_instance = setup_mock_db(mock_db)
             ...             expected_document = 'some_document'
             ...             expected_document_id = 'some_document_id'
             ...             mock_get_document_id.return_value = expected_document_id
             ...             driver = TinyDbDriver(di)
             ...             _ = driver._throwing_save(test_input_entry_struct)
-            ...             mock_document.assert_called_once_with(test_input_entry_struct, expected_document_id)
+            ...             mock_document.assert_called_once_with(
+            ...                 test_input_entry_struct, expected_document_id)
 
             2. TinyDbDriver::_throwing_save saves the struct of the reading entry
             >>> with patch.object(TinyDbDriver, '_db', new_callable=PropertyMock) as mock_db:
             ...     with patch.object(TinyDbDriver, '_get_document_id') as mock_get_document_id:
-            ...         with patch('reading_list.core.persistency.tinydb_driver.Document') as mock_document:
+            ...         with patch(
+            ...                 'reading_list.core.persistency.tinydb_driver.Document'
+            ...         ) as mock_document:
             ...             mock_db_instance = setup_mock_db(mock_db)
             ...             mock_document.return_value = expected_document
             ...             driver = TinyDbDriver(di)
             ...             _ = driver._throwing_save(test_input_entry_struct)
             ...             mock_db_instance.insert.assert_called_once_with(expected_document)
 
-            3. TinyDbDriver::_throwing_save returns True if the result of insert is a valid document id
+            3. TinyDbDriver::_throwing_save
+                returns True if the result of insert is a valid document id
             >>> with patch.object(TinyDbDriver, '_db', new_callable=PropertyMock) as mock_db:
             ...     with patch.object(TinyDbDriver, '_get_document_id') as mock_get_document_id:
-            ...         with patch('reading_list.core.persistency.tinydb_driver.Document') as mock_document:
+            ...         with patch(
+            ...                 'reading_list.core.persistency.tinydb_driver.Document'
+            ...         ) as mock_document:
             ...             mock_db_instance = setup_mock_db(mock_db)
             ...             mock_db_instance.insert.return_value = "some_valid_document_id"
             ...             driver = TinyDbDriver(di)
             ...             driver._throwing_save(test_input_entry_struct)
             True
 
-            4. TinyDbDriver::_throwing_save returns False if the result of insert is not a valid document id
+            4. TinyDbDriver::_throwing_save
+                returns False if the result of insert is not a valid document id
             >>> with patch.object(TinyDbDriver, '_db', new_callable=PropertyMock) as mock_db:
             ...     with patch.object(TinyDbDriver, '_get_document_id') as mock_get_document_id:
-            ...         with patch('reading_list.core.persistency.tinydb_driver.Document') as mock_document:
+            ...         with patch(
+            ...                 'reading_list.core.persistency.tinydb_driver.Document'
+            ...         ) as mock_document:
             ...             mock_db_instance = setup_mock_db(mock_db)
             ...             mock_db_instance.insert.return_value = None
             ...             driver = TinyDbDriver(di)
@@ -118,7 +133,7 @@ class TinyDbDriver:
     def _get_document_id(self, reading_entry_struct: ReadingEntryStruct) -> int:
         """Examples:
 
-            >>> from unittest.mock import MagicMock, patch
+            >>> from unittest.mock import MagicMock
             >>> mock_factory = MagicMock()
             >>> di = dict(reading_entry_factory=mock_factory)
             >>> test_instance = TinyDbDriver(di)
@@ -152,6 +167,7 @@ class TinyDbDriver:
 
     def list(self) -> List[ReadingEntryStruct]:
         """Examples:
+
             >>> from unittest.mock import MagicMock, PropertyMock, patch
             >>> di = dict()
             >>> def setup_mock_db(mock_db):

--- a/reading_list/core/persistency/tinydb_driver.py
+++ b/reading_list/core/persistency/tinydb_driver.py
@@ -3,8 +3,7 @@ from typing import List, Optional, cast
 from tinydb import TinyDB
 from tinydb.table import Document
 
-from reading_list.core.dependencies.dependency_injection import \
-    ADependencyInjectionContainer
+from reading_list.core.dependencies.dependency_injection import ADependencyInjectionContainer
 from reading_list.core.dependencies.keys import DependencyInjectionEntryKeys
 from reading_list.core.domain.entities import ReadingEntryStruct
 from reading_list.shared.config import DEFAULT_CONFIGS, Config

--- a/reading_list/shared/config.py
+++ b/reading_list/shared/config.py
@@ -6,7 +6,7 @@ import json
 
 class AConfig:
     """Required abstract class indicating a new configuration."""
-    pass
+    ...
 
 
 class TinyDbConfig(AConfig):
@@ -27,15 +27,13 @@ DEFAULT_CONFIGS = Config()
 def merge_configs(config: AConfig, custom_config: Optional[Dict[str, Any]] = None) -> AConfig:
     """Examples:
 
-    >>> from unittest.mock import patch, MagicMock
-
     >>> default_config_value = "bar"
     >>> class TestConfigClass(AConfig):
     ...     class TestConfigClassEmbedded(AConfig):
     ...         foo = default_config_value
     ...     sub_config = TestConfigClassEmbedded()
     ...     foo = default_config_value
-    ...     
+    ...
     ...     def __str__(self):
     ...         return f'foo: {self.foo}, sub_config: foo: {self.sub_config.foo}'
     ...
@@ -82,7 +80,7 @@ def merge_configs(config: AConfig, custom_config: Optional[Dict[str, Any]] = Non
 
 
 def initialize_custom_configs(config_path: str) -> AConfig:
-    with open(config_path) as f:
-        custom_config: Dict[str, Any] = json.load(f)
+    with open(config_path) as file:
+        custom_config: Dict[str, Any] = json.load(file)
     base_configs = Config()
     return merge_configs(base_configs, custom_config)

--- a/reading_list/shared/config.py
+++ b/reading_list/shared/config.py
@@ -1,7 +1,7 @@
-from typing import Any, Dict, Optional
-from inspect import getmembers
-import os
 import json
+import os
+from inspect import getmembers
+from typing import Any, Dict, Optional
 
 
 class AConfig:

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -2,3 +2,4 @@ autopep8==1.5.6
 mypy==0.812
 pytest==6.2.2
 flake8==3.9.2
+isort==5.9.3

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -1,4 +1,4 @@
 autopep8==1.5.6
 mypy==0.812
 pytest==6.2.2
-pylint==2.7.2
+flake8==3.9.2


### PR DESCRIPTION
# What

Cleanup code-style related issues: 

- Replace `pylint` with `flake8` (as it has a smaller footprint for now)
- Fix `flake8` reported errors
- Add `isort` for automated import sorting
- Adjust `Makefile` and GitHub Actions